### PR TITLE
Fix: missing 'gcc' and 'cc1plus' while building wheel for psutil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.9.14-slim
 
 WORKDIR /code
 
+RUN apt-get update
+RUN apt-get -y install gcc python3-dev python3-pip g++
+
 RUN pip install poetry
 RUN poetry config virtualenvs.create false
 COPY pyproject.toml /code/pyproject.toml


### PR DESCRIPTION
Hit error _command failed (missing executables) 'gcc' and 'cc1plus'_ during `docker build -t credit-score-prediction:dev .`

Adding gcc to base image
